### PR TITLE
Check if there are actually groups in the data dict

### DIFF
--- a/io_scene_minecraft_json/import_minecraft_json.py
+++ b/io_scene_minecraft_json/import_minecraft_json.py
@@ -13,9 +13,12 @@ def load(context,
     
     with open(filepath, 'r') as f:
         data = json.load(f)
-    
-    groups = data['groups']
+
     elements = data['elements']
+    groups = {}
+
+    if 'groups' in data:
+        groups = data['groups']    
 
     # objects created
     objects = []


### PR DESCRIPTION
I'm not the most familiar with JSON block models and have only recently been using them, but there doesn't seem to be anything about groups. 

Just scanning through the import code it might actually be a mistake/typo and you had intended to read the current blender groups?

Regardless, it was failing to import my model due to my JSON model not having the JSON element "groups"